### PR TITLE
- fixed screenshot crash on android

### DIFF
--- a/src/components/VerifyCreate/index.js
+++ b/src/components/VerifyCreate/index.js
@@ -26,6 +26,11 @@ export const VerifyCreate = ({navigation, route}) => {
     } else {
       disabledPreventScreenshot().then(_ => {});
     }
+    // Always deactivate on unmount too, so FLAG_SECURE can't be left set if the
+    // screen unmounts while still focused.
+    return () => {
+      disabledPreventScreenshot().then(_ => {});
+    };
   }, [isFocused]);
 
   if (!currentWallet?.phrase) {

--- a/src/screens/main/Wallets/CreateWallet/index.js
+++ b/src/screens/main/Wallets/CreateWallet/index.js
@@ -320,11 +320,14 @@ const CreateWallet = ({navigation, route}) => {
                         errors.name ? 'red' : theme.borderActiveColor
                       }
                       autoCapitalize="none"
-                      returnKeyType="next"
+                      autoCorrect={false}
+                      autoComplete="off"
+                      spellCheck={false}
+                      returnKeyType="done"
                       mode="outlined"
                       blurOnSubmit={false}
                       name="name"
-                      autoFocus={true}
+                      autoFocus={false}
                       onChangeText={handleChange('name')}
                       // onBlur={handleBlur('name')}
                       onBlur={() => {
@@ -332,7 +335,9 @@ const CreateWallet = ({navigation, route}) => {
                         handleBlur('currentPassword');
                       }}
                       value={values.name}
-                      // onSubmitEditing={handleSubmit}
+                      onSubmitEditing={() => {
+                        Keyboard.dismiss();
+                      }}
                     />
                     {errors.name && (
                       <Text style={styles.textConfirm}>{errors.name}</Text>

--- a/src/screens/main/Wallets/index.js
+++ b/src/screens/main/Wallets/index.js
@@ -270,6 +270,11 @@ const Wallets = ({navigation}) => {
           style={styles.input}
           onChangeText={handleSearch}
           autoFocus={false}
+          onSubmitEditing={() => Keyboard.dismiss()}
+          autoCorrect={false}
+          autoComplete="off"
+          autoCapitalize="none"
+          spellCheck={false}
           inputStyle={{minHeight: 0}}
         />
 

--- a/src/utils/screenshot.js
+++ b/src/utils/screenshot.js
@@ -1,8 +1,19 @@
 import ScreenGuardModule from 'react-native-screenguard';
 import screen_prevent from 'assets/images/screenshot_prevent.png';
+import {IS_ANDROID} from 'utils/dimensions';
 
 export const enablePreventScreenshot = async () => {
   try {
+    if (IS_ANDROID) {
+      // Android: FLAG_SECURE only. This blocks screenshots and screen
+      // recording without launching ScreenGuardColorActivity (a second
+      // ReactActivity), which otherwise races MainActivity's lifecycle and
+      // crashes RN with "Pausing an activity that is not the current activity".
+      await ScreenGuardModule.registerWithoutEffect();
+      return;
+    }
+    // iOS has no FLAG_SECURE, so it needs the overlay image to obscure the
+    // app snapshot, and it isn't affected by the Android multi-activity crash.
     const dataRequire = {
       height: 668,
       width: 375,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot protection behavior on Android to avoid lifecycle-related crashes.
  * Ensured screenshot protection is disabled when leaving the verification and creation screen.
  * Preserved the existing screenshot-prevention overlay behavior on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->